### PR TITLE
fix: default lts-only flag to false

### DIFF
--- a/src/commands/build.js
+++ b/src/commands/build.js
@@ -65,7 +65,7 @@ function build (info, settings) {
     },
     'lts-only': {
       describe: 'limits the build for LTS versions of Node only',
-      default: true,
+      default: false,
       boolean: 'boolean'
     },
     'no-push': {


### PR DESCRIPTION
this is preventing our containers from building because we don't use an lts version of node